### PR TITLE
Improve CI setting, psalm and namespaces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   phpunit:

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "~8.0",
-        "vimeo/psalm": "~3.7.0"
+        "vimeo/psalm": "^3.7"
     },
     "scripts": {
         "test": "vendor/bin/phpunit --colors=always"

--- a/tests/Status/Environment/LocalTest.php
+++ b/tests/Status/Environment/LocalTest.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types = 1);
 
-namespace Tests\Innmind\RabbitMQ\Management\Environment;
+namespace Tests\Innmind\RabbitMQ\Management\Status\Environment;
 
 use Innmind\RabbitMQ\Management\Status\{
     Environment\Local,

--- a/tests/Status/Environment/RemoteTest.php
+++ b/tests/Status/Environment/RemoteTest.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types = 1);
 
-namespace Tests\Innmind\RabbitMQ\Management\Environment;
+namespace Tests\Innmind\RabbitMQ\Management\Status\Environment;
 
 use Innmind\RabbitMQ\Management\Status\{
     Environment\Remote,


### PR DESCRIPTION
# Changed log

- Add `pull_request` trigger on GitHub action.
- To install latest Psalm version, it should define `^3.7` for `psalm` dependency.
- Fix namespaces for `RemoteTest` and `LocalTest` classes.
- GitHub action will be failed until issue #2 is resolved.